### PR TITLE
回路が完全に空の場合に対応

### DIFF
--- a/app/controllers/circuits_controller.rb
+++ b/app/controllers/circuits_controller.rb
@@ -50,7 +50,11 @@ class CircuitsController < ApplicationController
     max_qft_span = max_qft_span(circuit_json)
     max_oracle_span = max_oracle_span(circuit_json)
 
-    [max_col_gates, max_qft_span, max_oracle_span].max
+    max_qubit_count = [max_col_gates, max_qft_span, max_oracle_span].max
+
+    return 3 if max_qubit_count.zero?
+
+    max_qubit_count
   end
 
   def max_qft_span(circuit_json)


### PR DESCRIPTION
回路が完全に空の場合にもエラーを出さずに計算する (refs #55)。

![CleanShot 2024-11-12 at 09 59 36](https://github.com/user-attachments/assets/3bc35118-9899-41b5-90e0-bd4f8f9f2544)
